### PR TITLE
add mobile navigation

### DIFF
--- a/src/components/LoggedInHeader.tsx
+++ b/src/components/LoggedInHeader.tsx
@@ -73,10 +73,8 @@ export async function LoggedInHeader() {
           <DropdownMenuSeparator />
           <DropdownMenuGroup>
             {linksToDisplay.map((link, index) => (
-              <DropdownMenuItem>
-                <Link key={index} href={link.href}>
-                  {link.label}
-                </Link>
+              <DropdownMenuItem key={index}>
+                <Link href={link.href}>{link.label}</Link>
               </DropdownMenuItem>
             ))}
           </DropdownMenuGroup>


### PR DESCRIPTION
The middle section in the site header enlisting "Home, Chat, Classrooms" is hidden on small screens. However, we need those links to be visible somewhere for the mobile user too.

This PR adds the same navigation links to the avatar dropdown too, so that they are accessible to mobile users too.