### PR TITLE
move classroom sidebar to layout

### DIFF
--- a/src/app/classrooms/[classroomId]/assignments/page.tsx
+++ b/src/app/classrooms/[classroomId]/assignments/page.tsx
@@ -1,6 +1,5 @@
 import { AddEditAssignmentSheet } from "@/components/assignment/AddEditAssignmentSheet";
 import { AssignmentCard } from "@/components/classroom/AssignmentCard";
-import { ClassroomSidebar } from "@/components/classroom/ClassroomSidebar";
 import { NotAuthorizedToViewPage } from "@/components/NotAuthorizedToViewPage";
 import { PageBreadcrumbs } from "@/components/PageBreadcrumbs";
 import { Button } from "@/components/ui/button";

--- a/src/app/classrooms/[classroomId]/files/page.tsx
+++ b/src/app/classrooms/[classroomId]/files/page.tsx
@@ -1,4 +1,3 @@
-import { ClassroomSidebar } from "@/components/classroom/ClassroomSidebar";
 import { AddEditFileSheet } from "@/components/files/AddEditFileSheet";
 import { NotAuthorizedToViewPage } from "@/components/NotAuthorizedToViewPage";
 import { PageBreadcrumbs } from "@/components/PageBreadcrumbs";

--- a/src/app/classrooms/[classroomId]/layout.tsx
+++ b/src/app/classrooms/[classroomId]/layout.tsx
@@ -1,5 +1,4 @@
 import { ClassroomSidebar } from "@/components/classroom/ClassroomSidebar";
-import { PageBreadcrumbs } from "@/components/PageBreadcrumbs";
 
 export default async function ClassroomLayout({
   children,

--- a/src/app/classrooms/[classroomId]/page.tsx
+++ b/src/app/classrooms/[classroomId]/page.tsx
@@ -1,4 +1,3 @@
-import { ClassroomSidebar } from "@/components/classroom/ClassroomSidebar";
 import { NotAuthorizedToViewPage } from "@/components/NotAuthorizedToViewPage";
 import { PageBreadcrumbs } from "@/components/PageBreadcrumbs";
 import { EnumAccessType } from "@/schemas/dbTableAccessSchema";

--- a/src/app/classrooms/[classroomId]/participants/page.tsx
+++ b/src/app/classrooms/[classroomId]/participants/page.tsx
@@ -1,4 +1,3 @@
-import { ClassroomSidebar } from "@/components/classroom/ClassroomSidebar";
 import { AddEditParticipantSheet } from "@/components/classroom/participants/AddEditParticpantSheet";
 import { UsersTable } from "@/components/classroom/participants/UsersTable";
 import { NotAuthorizedToViewPage } from "@/components/NotAuthorizedToViewPage";

--- a/src/components/classroom/ClassroomSidebar.tsx
+++ b/src/components/classroom/ClassroomSidebar.tsx
@@ -27,7 +27,7 @@ export const ClassroomSidebarContent = ({
     <aside className="mr-4 mt-2 flex h-full min-w-40 max-w-40 flex-col border-r pl-2">
       <ul className="flex flex-col gap-2">
         {getClassroomSidebarLinks(classroomId).map((link) => (
-          <li className="max-w-fit">
+          <li key={link.href} className="max-w-fit">
             <Link href={link.href}>
               {link.label}
               <LinkHighlight href={link.href} />


### PR DESCRIPTION
refactored classroom sidebar to use layout - removes code duplication.

fixed mismatched alignment issue with the breadcrumbs and the menu-icon.

added highlights to active url in the side menu.