### PR TITLE
refactor question creation

### DIFF
--- a/drizzle.config.ts
+++ b/drizzle.config.ts
@@ -1,13 +1,10 @@
 import { defineConfig } from "drizzle-kit";
 import { configDotenv } from "@dotenvx/dotenvx";
-
 configDotenv({ path: ".env.local", override: true });
-
 const drizzleConfig = defineConfig({
   schema: "./src/server/db/schema/index.ts",
   out: "./src/server/db/migrations",
-  dialect: "sqlite",
-  driver: "turso",
+  dialect: "turso",
   dbCredentials: {
     // TODO: Remove `!` and make env typesafe with zod.
     url: process.env.DATABASE_URL!,
@@ -16,5 +13,4 @@ const drizzleConfig = defineConfig({
   strict: true,
   verbose: true,
 });
-
 export default drizzleConfig;

--- a/package-lock.json
+++ b/package-lock.json
@@ -57,7 +57,7 @@
         "@types/react-dom": "^18",
         "@typescript-eslint/eslint-plugin": "^7.16.1",
         "drizzle-dbml-generator": "^0.10.0",
-        "drizzle-kit": "^0.22.7",
+        "drizzle-kit": "0.30.4",
         "eslint": "^8",
         "eslint-config-next": "14.2.4",
         "eslint-plugin-drizzle": "^0.2.3",
@@ -1390,6 +1390,12 @@
       "engines": {
         "node": "^16.13.0 || >=18.0.0"
       }
+    },
+    "node_modules/@drizzle-team/brocli": {
+      "version": "0.10.2",
+      "resolved": "https://registry.npmjs.org/@drizzle-team/brocli/-/brocli-0.10.2.tgz",
+      "integrity": "sha512-z33Il7l5dKjUgGULTqBsQBQwckHh5AbIuxhdsIxDDiZAzBOrZO6q9ogcWC65kU382AfynTfgNumVcNIjuIua6w==",
+      "dev": true
     },
     "node_modules/@esbuild-kit/core-utils": {
       "version": "3.3.2",
@@ -6400,11 +6406,12 @@
       }
     },
     "node_modules/drizzle-kit": {
-      "version": "0.22.8",
-      "resolved": "https://registry.npmjs.org/drizzle-kit/-/drizzle-kit-0.22.8.tgz",
-      "integrity": "sha512-VjI4wsJjk3hSqHSa3TwBf+uvH6M6pRHyxyoVbt935GUzP9tUR/BRZ+MhEJNgryqbzN2Za1KP0eJMTgKEPsalYQ==",
+      "version": "0.30.4",
+      "resolved": "https://registry.npmjs.org/drizzle-kit/-/drizzle-kit-0.30.4.tgz",
+      "integrity": "sha512-B2oJN5UkvwwNHscPWXDG5KqAixu7AUzZ3qbe++KU9SsQ+cZWR4DXEPYcvWplyFAno0dhRJECNEhNxiDmFaPGyQ==",
       "dev": true,
       "dependencies": {
+        "@drizzle-team/brocli": "^0.10.2",
         "@esbuild-kit/esm-loader": "^2.5.5",
         "esbuild": "^0.19.7",
         "esbuild-register": "^3.5.0"

--- a/package.json
+++ b/package.json
@@ -62,7 +62,7 @@
     "@types/react-dom": "^18",
     "@typescript-eslint/eslint-plugin": "^7.16.1",
     "drizzle-dbml-generator": "^0.10.0",
-    "drizzle-kit": "^0.22.7",
+    "drizzle-kit": "0.30.4",
     "eslint": "^8",
     "eslint-config-next": "14.2.4",
     "eslint-plugin-drizzle": "^0.2.3",

--- a/src/components/assignment/AssignmentQuestions.tsx
+++ b/src/components/assignment/AssignmentQuestions.tsx
@@ -12,6 +12,7 @@ import { EnumFormMode } from "@/schemas/formSchema";
 import assert from "assert";
 import { canUserAccessAssignment } from "@/utils/classroom/canUserAccessAssignment";
 import { EnumAccessType } from "@/schemas/dbTableAccessSchema";
+import ChooseQuestionTypeDialog from "../question/add/ChooseQuestionTypeDialog";
 
 type QuestionTitleProps = {
   id: string;
@@ -80,14 +81,11 @@ export async function AssignmentQuestions({
         <AlertOctagonIcon className="h-24 w-24" />
         <p>No questions found</p>
         {isAuthorizedToAddOrDelete && (
-          <AddEditQuestionSheet
-            mode={EnumFormMode.Add}
-            assignmentId={assignmentId}
-          >
+          <ChooseQuestionTypeDialog assignmentId={assignmentId}>
             <Button className="flex gap-2">
               Add a question <ShieldQuestionIcon />
             </Button>
-          </AddEditQuestionSheet>
+          </ChooseQuestionTypeDialog>
         )}
       </div>
     );
@@ -101,14 +99,11 @@ export async function AssignmentQuestions({
       })}
       {isAuthorizedToAddOrDelete && (
         <li>
-          <AddEditQuestionSheet
-            mode={EnumFormMode.Add}
-            assignmentId={assignmentId}
-          >
+          <ChooseQuestionTypeDialog assignmentId={assignmentId}>
             <Button className="mt-2 flex gap-2">
               Add another question <ShieldQuestionIcon />
             </Button>
-          </AddEditQuestionSheet>
+          </ChooseQuestionTypeDialog>
         </li>
       )}
     </ol>

--- a/src/components/question/AddEditQuestionSheet.tsx
+++ b/src/components/question/AddEditQuestionSheet.tsx
@@ -8,7 +8,6 @@ import {
   SheetTitle,
   SheetTrigger,
 } from "@/components/ui/sheet";
-import { AddQuestionForm } from "./add/AddQuestionForm";
 import { type PropsWithChildren, Suspense, useState } from "react";
 import { type AddEditQuestionSheetProps } from "@/schemas/questionSchema";
 import {
@@ -42,9 +41,7 @@ export function AddEditQuestionSheet({
           <SheetTitle>{questionSheetTitle[mode]}</SheetTitle>
           <SheetDescription>{questionSheetDescription[mode]}</SheetDescription>
         </SheetHeader>
-        {mode === EnumFormMode.Add ? (
-          <AddQuestionForm {...props} setIsOpen={setIsOpen} />
-        ) : (
+        {mode === EnumFormMode.Edit && (
           <Suspense fallback={<EditQuestionFormFallback />}>
             <EditQuestionForm {...props} setIsOpen={setIsOpen} />
           </Suspense>

--- a/src/components/question/add/AddCodeQuestionForm.tsx
+++ b/src/components/question/add/AddCodeQuestionForm.tsx
@@ -1,0 +1,111 @@
+"use client";
+
+import { addQuestion } from "@/actions/addQuestion";
+import { Button } from "@/components/ui/button";
+import {
+  Form,
+  FormControl,
+  FormDescription,
+  FormField,
+  FormItem,
+  FormLabel,
+  FormMessage,
+} from "@/components/ui/form";
+import { SheetFooter } from "@/components/ui/sheet";
+import { Textarea } from "@/components/ui/textarea";
+import { toast } from "@/components/ui/use-toast";
+import {
+  addQuestionFormSchema,
+  EnumAddQuestionResult,
+  EnumQuestionType,
+  type AddCodeQuestionForm as AddCodeQuestionFormType,
+} from "@/schemas/questionSchema";
+import { FormIds } from "@/utils/constants/form";
+import { toastDescriptionAddQuestion } from "@/utils/constants/toast";
+import { type WithSheetOpenStateSetter } from "@/utils/types";
+import { zodResolver } from "@hookform/resolvers/zod";
+import { useAction } from "next-safe-action/hooks";
+import { useRouter } from "next/navigation";
+import { type DefaultValues, useForm } from "react-hook-form";
+import { AddQuestionFormCommonFields } from "./AddQuestionFormCommonFields";
+
+type AddCodeQuestionFormProps = {
+  assignmentId: string;
+};
+
+export function AddCodeQuestionForm({
+  assignmentId,
+  setIsOpen,
+}: WithSheetOpenStateSetter<AddCodeQuestionFormProps>) {
+  const defaultValues: DefaultValues<AddCodeQuestionFormType> = {
+    type: EnumQuestionType.Code,
+    assignmentId,
+    name: "",
+    question: "",
+    starterCode: "",
+  };
+
+  const form = useForm<AddCodeQuestionFormType>({
+    resolver: zodResolver(addQuestionFormSchema),
+    defaultValues,
+  });
+
+  const router = useRouter();
+  const { executeAsync } = useAction(addQuestion, {
+    onSuccess({ data }) {
+      if (!data?.type) return;
+
+      const isErroneous = data.type !== EnumAddQuestionResult.QuestionAdded;
+
+      toast({
+        title: isErroneous
+          ? "Error in adding Question"
+          : "Question added successfully",
+        description: toastDescriptionAddQuestion[data.type],
+        variant: isErroneous ? "destructive" : "default",
+      });
+
+      if (!isErroneous) {
+        form.reset();
+        setIsOpen(false);
+        router.refresh();
+      }
+    },
+  });
+
+  return (
+    <Form {...form}>
+      <form
+        id={FormIds.AddCodeQuestion}
+        onSubmit={form.handleSubmit(executeAsync)}
+        className="flex h-full flex-col gap-4"
+      >
+        <AddQuestionFormCommonFields
+          type={EnumQuestionType.SingleCorrectMcq}
+          form={form}
+        />
+        <FormField
+          control={form.control}
+          name="starterCode"
+          render={({ field }) => (
+            <FormItem>
+              <FormLabel>Starter code</FormLabel>
+              <FormControl>
+                <Textarea required {...field} />
+              </FormControl>
+              <FormDescription>
+                Stubbed code to assist the user in solving questions
+              </FormDescription>
+              <FormMessage />
+            </FormItem>
+          )}
+        />
+      </form>
+      <SheetFooter>
+        <Button type="submit" form={FormIds.AddCodeQuestion}>
+          Add
+        </Button>
+      </SheetFooter>
+    </Form>
+  );
+}

--- a/src/components/question/add/AddQuestionForm.tsx
+++ b/src/components/question/add/AddQuestionForm.tsx
@@ -1,172 +1,27 @@
 "use client";
 
-import { useAction } from "next-safe-action/hooks";
-import { zodResolver } from "@hookform/resolvers/zod";
-import {
-  Form,
-  FormControl,
-  FormDescription,
-  FormField,
-  FormItem,
-  FormLabel,
-  FormMessage,
-} from "@/components/ui/form";
-import { type DefaultValues, useForm } from "react-hook-form";
-import { toast } from "@/components/ui/use-toast";
-import { toastDescriptionAddQuestion } from "@/utils/constants/toast";
-import {
-  type AddQuestionForm as AddQuestionFormType,
-  addQuestionFormSchema,
-  EnumAddQuestionResult,
-  EnumQuestionType,
-} from "@/schemas/questionSchema";
-import { FormIds } from "@/utils/constants/form";
-import { addQuestion } from "@/actions/addQuestion";
-import { type Dispatch, type SetStateAction } from "react";
-import { useRouter } from "next/navigation";
-import { Button } from "../../ui/button";
-import { SheetFooter } from "../../ui/sheet";
-import {
-  Select,
-  SelectContent,
-  SelectItem,
-  SelectTrigger,
-  SelectValue,
-} from "@/components/ui/select";
-import { AddCodeQuestionFormFields } from "./AddCodeQuestionFormFields";
-import { Input } from "@/components/ui/input";
-import { Textarea } from "@/components/ui/textarea";
-import { AddSingleCorrectFormFields } from "./AddSingleCorrectMcqFormFields";
+import { EnumQuestionType, type QuestionType } from "@/schemas/questionSchema";
 
-type AddQuestionFormComponentProps = {
+import { AddCodeQuestionForm } from "./AddCodeQuestionForm";
+
+import { AddSingleCorrectFormFields } from "./AddSingleCorrectMcqFormFields";
+import { type WithSheetOpenStateSetter } from "@/utils/types";
+
+type AddQuestionFormProps = {
+  type: QuestionType;
   assignmentId: string;
-  setIsOpen: Dispatch<SetStateAction<boolean>>;
 };
 
 export const AddQuestionForm = ({
-  assignmentId,
-  setIsOpen,
-}: AddQuestionFormComponentProps) => {
-  const addQuestionFormDefaultValues: DefaultValues<AddQuestionFormType> = {
-    type: EnumQuestionType.SingleCorrectMcq,
-    assignmentId,
-    name: "",
-    question: "",
-  };
-
-  const router = useRouter();
-  const form = useForm<AddQuestionFormType>({
-    resolver: zodResolver(addQuestionFormSchema),
-    defaultValues: addQuestionFormDefaultValues,
-  });
-
-  const { executeAsync } = useAction(addQuestion, {
-    onSuccess({ data }) {
-      if (!data?.type) return;
-
-      const isErroneous = data.type !== EnumAddQuestionResult.QuestionAdded;
-
-      toast({
-        title: isErroneous
-          ? "Error in adding Question"
-          : "Question added successfully",
-        description: toastDescriptionAddQuestion[data.type],
-        variant: isErroneous ? "destructive" : "default",
-      });
-
-      if (!isErroneous) {
-        form.reset();
-        setIsOpen(false);
-        router.refresh();
-      }
-    },
-  });
-
-  const questionType = form.watch("type");
-
-  return (
-    <Form {...form}>
-      <form
-        id={FormIds.AddQuestion}
-        onSubmit={form.handleSubmit(executeAsync)}
-        className="flex h-full flex-col gap-4"
-      >
-        <FormField
-          control={form.control}
-          name="type"
-          render={({ field }) => (
-            <FormItem>
-              <FormLabel>Type</FormLabel>
-              <FormControl>
-                <Select {...field} onValueChange={field.onChange}>
-                  <SelectTrigger>
-                    <SelectValue placeholder="Select a role" />
-                  </SelectTrigger>
-                  <SelectContent>
-                    <SelectItem value={EnumQuestionType.Code}>Code</SelectItem>
-                    <SelectItem value={EnumQuestionType.SingleCorrectMcq}>
-                      Single-correct MCQ
-                    </SelectItem>
-                    <SelectItem value={EnumQuestionType.MultiCorrectMcq}>
-                      Multi-correct MCQ
-                    </SelectItem>
-                  </SelectContent>
-                </Select>
-              </FormControl>
-              <FormDescription>
-                The type of question you want to ask
-              </FormDescription>
-              <FormMessage />
-            </FormItem>
-          )}
-        />
-        <FormField
-          control={form.control}
-          name="name"
-          render={({ field }) => (
-            <FormItem>
-              <FormLabel>Name</FormLabel>
-              <FormControl>
-                <Input required {...field} />
-              </FormControl>
-              <FormDescription>Name of the question</FormDescription>
-              <FormMessage />
-            </FormItem>
-          )}
-        />
-        <FormField
-          control={form.control}
-          name="question"
-          render={({ field }) => (
-            <FormItem>
-              <FormLabel>Question</FormLabel>
-              <FormControl>
-                <Textarea required {...field} />
-              </FormControl>
-              <FormDescription>The question text</FormDescription>
-              <FormMessage />
-            </FormItem>
-          )}
-        />
-        {/* TODO: Figure out a type-safe way of managing these forms */}
-        {questionType === EnumQuestionType.Code && (
-          <>
-            {/* @ts-expect-error watch above TODO */}
-            <AddCodeQuestionFormFields form={form} />
-          </>
-        )}
-        {questionType === EnumQuestionType.SingleCorrectMcq && (
-          <>
-            {/* @ts-expect-error watch above TODO */}
-            <AddSingleCorrectFormFields form={form} />
-          </>
-        )}
-      </form>
-      <SheetFooter>
-        <Button type="submit" form={FormIds.AddQuestion}>
-          Add
-        </Button>
-      </SheetFooter>
-    </Form>
-  );
+  type,
+  ...rest
+}: WithSheetOpenStateSetter<AddQuestionFormProps>) => {
+  switch (type) {
+    case EnumQuestionType.Code:
+      return <AddCodeQuestionForm {...rest} />;
+    case EnumQuestionType.SingleCorrectMcq:
+      return <AddSingleCorrectFormFields {...rest} />;
+    case EnumQuestionType.MultiCorrectMcq:
+      return <AddSingleCorrectFormFields {...rest} />;
+  }
 };

--- a/src/components/question/add/AddQuestionForm.tsx
+++ b/src/components/question/add/AddQuestionForm.tsx
@@ -4,7 +4,6 @@ import { EnumQuestionType, type QuestionType } from "@/schemas/questionSchema";
 
 import { AddCodeQuestionForm } from "./AddCodeQuestionForm";
 
-import { AddSingleCorrectFormFields } from "./AddSingleCorrectMcqFormFields";
 import { type WithSheetOpenStateSetter } from "@/utils/types";
 
 type AddQuestionFormProps = {
@@ -19,9 +18,11 @@ export const AddQuestionForm = ({
   switch (type) {
     case EnumQuestionType.Code:
       return <AddCodeQuestionForm {...rest} />;
-    case EnumQuestionType.SingleCorrectMcq:
-      return <AddSingleCorrectFormFields {...rest} />;
-    case EnumQuestionType.MultiCorrectMcq:
-      return <AddSingleCorrectFormFields {...rest} />;
+    // case EnumQuestionType.SingleCorrectMcq:
+    //   return <AddSingleCorrectFormFields {...rest} />;
+    // case EnumQuestionType.MultiCorrectMcq:
+    //   return <AddSingleCorrectFormFields {...rest} />;
+    default:
+      return null;
   }
 };

--- a/src/components/question/add/AddQuestionFormCommonFields.tsx
+++ b/src/components/question/add/AddQuestionFormCommonFields.tsx
@@ -1,0 +1,103 @@
+"use client";
+
+import {
+  FormControl,
+  FormDescription,
+  FormField,
+  FormItem,
+  FormLabel,
+  FormMessage,
+} from "@/components/ui/form";
+import { type UseFormReturn } from "react-hook-form";
+import {
+  type AddCodeQuestionForm,
+  type AddMultiCorrectMCQQuestionForm,
+  type AddSingleCorrectMCQQuestionForm,
+  EnumQuestionType,
+  type QuestionType,
+} from "@/schemas/questionSchema";
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@/components/ui/select";
+import { Input } from "@/components/ui/input";
+import { Textarea } from "@/components/ui/textarea";
+
+type AddQuestionFormCommonFieldsProps<T extends QuestionType> = {
+  type: T;
+  form: T extends typeof EnumQuestionType.Code
+    ? UseFormReturn<AddCodeQuestionForm>
+    : T extends typeof EnumQuestionType.SingleCorrectMcq
+      ? UseFormReturn<AddSingleCorrectMCQQuestionForm>
+      : T extends typeof EnumQuestionType.MultiCorrectMcq
+        ? UseFormReturn<AddMultiCorrectMCQQuestionForm>
+        : never;
+};
+
+export const AddQuestionFormCommonFields =
+  ({}: AddQuestionFormCommonFieldsProps<QuestionType>) => {
+    return (
+      <>
+        <FormField
+          // control={form.control}
+          name="type"
+          render={({ field }) => (
+            <FormItem>
+              <FormLabel>Type</FormLabel>
+              <FormControl>
+                <Select {...field} onValueChange={field.onChange}>
+                  <SelectTrigger>
+                    <SelectValue placeholder="Select a role" />
+                  </SelectTrigger>
+                  <SelectContent>
+                    <SelectItem value={EnumQuestionType.Code}>Code</SelectItem>
+                    <SelectItem value={EnumQuestionType.SingleCorrectMcq}>
+                      Single-correct MCQ
+                    </SelectItem>
+                    <SelectItem value={EnumQuestionType.MultiCorrectMcq}>
+                      Multi-correct MCQ
+                    </SelectItem>
+                  </SelectContent>
+                </Select>
+              </FormControl>
+              <FormDescription>
+                The type of question you want to ask
+              </FormDescription>
+              <FormMessage />
+            </FormItem>
+          )}
+        />
+        <FormField
+          // control={form.control}
+          name="name"
+          render={({ field }) => (
+            <FormItem>
+              <FormLabel>Name</FormLabel>
+              <FormControl>
+                <Input required {...field} />
+              </FormControl>
+              <FormDescription>Name of the question</FormDescription>
+              <FormMessage />
+            </FormItem>
+          )}
+        />
+        <FormField
+          // control={form.control}
+          name="question"
+          render={({ field }) => (
+            <FormItem>
+              <FormLabel>Question</FormLabel>
+              <FormControl>
+                <Textarea required {...field} />
+              </FormControl>
+              <FormDescription>The question text</FormDescription>
+              <FormMessage />
+            </FormItem>
+          )}
+        />
+      </>
+    );
+  };

--- a/src/components/question/add/ChooseQuestionTypeDialog.tsx
+++ b/src/components/question/add/ChooseQuestionTypeDialog.tsx
@@ -1,0 +1,187 @@
+"use client";
+
+import React, { type PropsWithChildren, useState } from "react";
+import {
+  Dialog,
+  DialogTrigger,
+  DialogContent,
+  DialogTitle,
+  DialogDescription,
+  DialogClose,
+} from "@/components/ui/dialog";
+import { Button } from "@/components/ui/button";
+import { useForm } from "react-hook-form";
+import {
+  Form,
+  FormControl,
+  FormField,
+  FormItem,
+  FormLabel,
+} from "@/components/ui/form";
+import { z } from "zod";
+import { EnumQuestionType, type QuestionType } from "@/schemas/questionSchema";
+import { zodResolver } from "@hookform/resolvers/zod";
+import { RadioGroup, RadioGroupItem } from "@/components/ui/radio-group";
+import {
+  ArrowRightCircleIcon,
+  Code2Icon,
+  ListCheckIcon,
+  ListChecksIcon,
+} from "lucide-react";
+import { CheckIcon } from "@radix-ui/react-icons";
+import { cn } from "@/utils/cn";
+import {
+  Sheet,
+  SheetContent,
+  SheetDescription,
+  SheetHeader,
+  SheetTitle,
+  SheetTrigger,
+} from "@/components/ui/sheet";
+import { addQuestionSheetConfigByQuestionType } from "@/utils/constants/question";
+import { AddQuestionForm } from "./AddQuestionForm";
+
+const questionTypeSchema = z.object({
+  type: z.enum([
+    EnumQuestionType.Code,
+    EnumQuestionType.SingleCorrectMcq,
+    EnumQuestionType.MultiCorrectMcq,
+  ]),
+});
+
+type _QuestionType = z.infer<typeof questionTypeSchema>;
+
+const getUiConfigByQuestionType = (type: QuestionType) => {
+  switch (type) {
+    case EnumQuestionType.Code:
+      return {
+        type,
+        title: "Code ",
+        icon: <Code2Icon />,
+      };
+    case EnumQuestionType.SingleCorrectMcq:
+      return {
+        type,
+        title: "Single Correct",
+        icon: <ListCheckIcon />,
+      };
+    case EnumQuestionType.MultiCorrectMcq:
+      return {
+        type,
+        title: "Multi Correct",
+        icon: <ListChecksIcon />,
+      };
+  }
+};
+
+type ChooseQuestionTypeDialogProps = {
+  assignmentId: string;
+};
+
+const ChooseQuestionTypeDialog = ({
+  children,
+  assignmentId,
+}: PropsWithChildren<ChooseQuestionTypeDialogProps>) => {
+  const [isDialogOpen, setIsDialogOpen] = useState(false);
+  const [isSheetOpen, setIsSheetOpen] = useState(false);
+
+  const form = useForm<_QuestionType>({
+    resolver: zodResolver(questionTypeSchema),
+    defaultValues: { type: EnumQuestionType.Code },
+  });
+
+  const questionType = form.watch("type");
+  const questionSheetConfig =
+    addQuestionSheetConfigByQuestionType[questionType];
+
+  return (
+    <>
+      <Dialog open={isDialogOpen} onOpenChange={setIsDialogOpen}>
+        <DialogTrigger asChild>{children}</DialogTrigger>
+        <DialogContent>
+          <DialogTitle>Choose Question Type</DialogTitle>
+          <DialogDescription>
+            Select the type of question you want to add.
+          </DialogDescription>
+          <Form {...form}>
+            <div className="flex flex-row items-center justify-between gap-4">
+              <FormField
+                control={form.control}
+                name="type"
+                render={({ field }) => (
+                  <FormItem>
+                    <FormControl>
+                      <RadioGroup
+                        {...field}
+                        onValueChange={field.onChange}
+                        className="flex flex-row items-center gap-4"
+                      >
+                        {Object.values(EnumQuestionType)
+                          .map(getUiConfigByQuestionType)
+                          .map(({ type, title, icon }) => {
+                            const isSelected = field.value === type;
+
+                            return (
+                              <FormItem
+                                className={cn(
+                                  isSelected
+                                    ? "bg-green-700"
+                                    : "hover:bg-muted",
+                                  "flex flex-col rounded-lg border-2 border-border pb-4"
+                                )}
+                                key={type}
+                              >
+                                <FormLabel className="flex h-20 w-20 flex-col items-center justify-center gap-2">
+                                  {icon}
+                                  <p className="text-center">{title}</p>
+                                </FormLabel>
+                                <div className="flex w-full items-center justify-center">
+                                  <FormControl>
+                                    <RadioGroupItem
+                                      value={type}
+                                      indicator={<CheckIcon className="!m-0" />}
+                                      className="!m-0 flex items-center"
+                                    />
+                                  </FormControl>
+                                </div>
+                              </FormItem>
+                            );
+                          })}
+                      </RadioGroup>
+                    </FormControl>
+                  </FormItem>
+                )}
+              />
+              <Sheet open={isSheetOpen} onOpenChange={setIsSheetOpen}>
+                <SheetTrigger asChild>
+                  <Button className="flex h-full flex-col gap-2">
+                    <ArrowRightCircleIcon />
+                    Next
+                  </Button>
+                </SheetTrigger>
+                <SheetContent className="flex h-full max-w-72 flex-col sm:max-w-[425px]">
+                  <SheetHeader>
+                    <SheetTitle>{questionSheetConfig.title}</SheetTitle>
+                    <SheetDescription>
+                      {questionSheetConfig.description}
+                    </SheetDescription>
+                  </SheetHeader>
+                  <AddQuestionForm
+                    type={questionType}
+                    assignmentId={assignmentId}
+                    setIsOpen={setIsSheetOpen}
+                  />
+                </SheetContent>
+              </Sheet>
+            </div>
+          </Form>
+          <DialogClose asChild>
+            <Button variant="destructive">Cancel</Button>
+          </DialogClose>
+        </DialogContent>
+      </Dialog>
+    </>
+  );
+};
+
+export default ChooseQuestionTypeDialog;

--- a/src/components/ui/sheet.tsx
+++ b/src/components/ui/sheet.tsx
@@ -7,7 +7,11 @@ import { cva, type VariantProps } from "class-variance-authority";
 
 import { cn } from "@/utils/cn";
 
-const Sheet = SheetPrimitive.Root;
+const Sheet = ({
+  ...props
+}: React.ComponentProps<typeof SheetPrimitive.Root>) => (
+  <SheetPrimitive.Root {...props} />
+);
 
 const SheetTrigger = SheetPrimitive.Trigger;
 

--- a/src/utils/constants/form.ts
+++ b/src/utils/constants/form.ts
@@ -5,7 +5,7 @@ export const FormIds = {
   RejectInvite: "rejectInviteForm",
   AddClassroom: "createClassroomForm",
   AddAssignment: "addAssignmentForm",
-  AddQuestion: "addQuestionForm",
+  AddCodeQuestion: "addCodeQuestionForm",
   AddFile: "addFileForm",
   EditFile: "editFileForm",
   EditClassroom: "editClassroomForm",

--- a/src/utils/constants/question.ts
+++ b/src/utils/constants/question.ts
@@ -1,17 +1,45 @@
 import { EnumFormMode, type FormMode } from "@/schemas/formSchema";
+import { EnumQuestionType, type QuestionType } from "@/schemas/questionSchema";
 
-/** Title of the sheet shown when dealing with questions */
+/** @deprecated Title of the sheet shown when dealing with questions */
 export const questionSheetTitle: Record<FormMode, string> = {
   [EnumFormMode.Add]: "Add Question",
   [EnumFormMode.Edit]: "Edit Question",
 };
 
-/** Description of the sheet shown when dealing with questions */
+/** @deprecated Description of the sheet shown when dealing with questions */
 export const questionSheetDescription: Record<FormMode, string> = {
   [EnumFormMode.Add]:
     "You're now creating a new question. Specify a name and your question's text. Then, click add when you're done.",
   [EnumFormMode.Edit]:
     "You're now editing a questions. Modify what you need to, then click save when you're done.",
+};
+
+/**
+ * Title and Description of the sheet shown when adding a question based on its type
+ */
+export const addQuestionSheetConfigByQuestionType: Record<
+  QuestionType,
+  {
+    title: string;
+    description: string;
+  }
+> = {
+  [EnumQuestionType.Code]: {
+    title: "Add a Code Question",
+    description:
+      "You're now creating a new code question. Specify a name, question's text, starter code and then, click add when you're done.",
+  },
+  [EnumQuestionType.SingleCorrectMcq]: {
+    title: "Add a Single Correct MCQ",
+    description:
+      "You're now creating a new single correct MCQ. Specify a name, question's text, its options and the one correct answer. Then, click add when you're done.",
+  },
+  [EnumQuestionType.MultiCorrectMcq]: {
+    title: "Add a Multi Correct MCQ",
+    description:
+      "You're now creating a new multiple correct MCQ. Specify a name, question's text, its options and one or more correct answers. Then, click add when you're done.",
+  },
 };
 
 export const EnumTabsContentType = {

--- a/src/utils/types.ts
+++ b/src/utils/types.ts
@@ -5,6 +5,7 @@ import {
   type EnumQuestionType,
   type QuestionType,
 } from "@/schemas/questionSchema";
+import { type Dispatch, type SetStateAction } from "react";
 import { type z } from "zod";
 
 export type ExtractQuestionForm<T extends QuestionType> =
@@ -15,3 +16,7 @@ export type ExtractQuestionForm<T extends QuestionType> =
       : T extends typeof EnumQuestionType.MultiCorrectMcq
         ? z.infer<typeof addMultiCorrectMCQQuestionFormSchema>
         : never;
+
+export type WithSheetOpenStateSetter<T> = T & {
+  setIsOpen: Dispatch<SetStateAction<boolean>>;
+};


### PR DESCRIPTION
This PR refactors creating questions to simplify adding more question types.

Earlier, the pattern of adding new questions was to have a single component control whether to show the "Add" form or "Edit" form for question. However, this approach was quite tedious for the add question form which was now going to have data being a discriminated union for different types of questions.

Therefore, decided to move to a new structure only for question types, where we choose the question type before hand, and then render question-type specific form based on the type. This approach strikes the best balance of DRY and duplication.