### PR TITLE
save edits for mcq

### DIFF
--- a/src/components/assignment/QuestionTitle.tsx
+++ b/src/components/assignment/QuestionTitle.tsx
@@ -15,6 +15,7 @@ import { ViewSingleCorrectMcq } from "../question/ViewSingleCorrectMcq";
 import { getSingleCorrectMcqByIdForAttempt } from "@/utils/classroom/question/getSingleCorrectMcqByIdForAttempt";
 import { getMultiCorrectMcqByIdForAttempt } from "@/utils/classroom/question/getMultiCorrectMcqByIdForAttempt";
 import { ViewMultiCorrectMcq } from "../question/ViewMultiCorrectMcq";
+import { Suspense } from "react";
 
 type QuestionTitleProps = {
   isAuthorizedToAddOrDelete: boolean;
@@ -114,7 +115,11 @@ export function QuestionTitle({
         )}
       </div>
       {type !== EnumQuestionType.Code && (
-        <AccordionContent>{viewQuestion()}</AccordionContent>
+        <AccordionContent>
+          <Suspense fallback={<div>Loading the question...</div>}>
+            {viewQuestion()}
+          </Suspense>
+        </AccordionContent>
       )}
     </AccordionItem>
   );

--- a/src/components/question/ViewMultiCorrectMcq.tsx
+++ b/src/components/question/ViewMultiCorrectMcq.tsx
@@ -38,7 +38,7 @@ export function ViewMultiCorrectMcq({
   };
 
   const { executeAsync, isExecuting } = useAction(saveMcqSelection, {
-    onSettled({ result: { data, serverError, validationErrors } }) {
+    onSettled({ result: { data } }) {
       if (!data) return;
 
       const isErroneous =
@@ -60,12 +60,12 @@ export function ViewMultiCorrectMcq({
   });
 
   const selectedOptions = form.watch("selectedOptions");
-  const toggleSelectOption = (value: string) => {
+  const toggleSelectOption = async (value: string) => {
     const newSelectedOptions = selectedOptions.includes(value)
       ? selectedOptions.filter((o) => o !== value)
       : [...selectedOptions, value];
     form.setValue("selectedOptions", newSelectedOptions);
-    form.handleSubmit(executeAsync)();
+    await form.handleSubmit(executeAsync)();
   };
 
   return (

--- a/src/components/question/ViewSingleCorrectMcq.tsx
+++ b/src/components/question/ViewSingleCorrectMcq.tsx
@@ -75,9 +75,9 @@ export function ViewSingleCorrectMcq({
                     <RadioGroup
                       {...field}
                       name={field.name}
-                      onValueChange={(newValue) => {
+                      onValueChange={async (newValue) => {
                         field.onChange(newValue);
-                        form.handleSubmit(executeAsync)();
+                        await form.handleSubmit(executeAsync)();
                       }}
                       defaultValue={field.value}
                       value={field.value}

--- a/src/components/question/ViewSingleCorrectMcq.tsx
+++ b/src/components/question/ViewSingleCorrectMcq.tsx
@@ -32,18 +32,13 @@ export function ViewSingleCorrectMcq({
   questionPromise,
 }: ViewSingleCorrectMcqProps) {
   const question = use(questionPromise);
-
   const defaultValues: DefaultValues<SaveMcqSelectionInput> = {
     type: EnumQuestionType.SingleCorrectMcq,
     questionId: question.id,
     selectedOption: question.selectedOption,
   };
-  const form = useForm<SaveMcqSelectionInput>({
-    resolver: zodResolver(saveMcqSelectionInputSchema),
-    defaultValues,
-  });
 
-  useAction(saveMcqSelection, {
+  const { executeAsync, isExecuting } = useAction(saveMcqSelection, {
     onSettled({ result: { data } }) {
       if (!data) return;
 
@@ -59,14 +54,11 @@ export function ViewSingleCorrectMcq({
     },
   });
 
-  // console.log("YOOOO");
-
-  // const values = form.watch();
-  // const debouncedValues = useDebounce(values, 500);
-  // const stringifiedValues = JSON.stringify(debouncedValues);
-  // useEffect(() => {
-  //   executeAsync(JSON.parse(stringifiedValues));
-  // }, [stringifiedValues]);
+  const form = useForm<SaveMcqSelectionInput>({
+    resolver: zodResolver(saveMcqSelectionInputSchema),
+    defaultValues,
+    disabled: isExecuting,
+  });
 
   return (
     <div className="flex p-4">
@@ -81,9 +73,14 @@ export function ViewSingleCorrectMcq({
                 <FormItem>
                   <FormControl>
                     <RadioGroup
+                      {...field}
                       name={field.name}
-                      onValueChange={field.onChange}
-                      defaultValue={question.selectedOption}
+                      onValueChange={(newValue) => {
+                        field.onChange(newValue);
+                        form.handleSubmit(executeAsync)();
+                      }}
+                      defaultValue={field.value}
+                      value={field.value}
                     >
                       {question.options.map(({ value, label }) => {
                         return (

--- a/src/schemas/questionSchema.ts
+++ b/src/schemas/questionSchema.ts
@@ -333,17 +333,21 @@ export const EnumResetCodeResult = {
 const resetCodeResultSchema = z.nativeEnum(EnumResetCodeResult);
 export type ResetCodeResult = z.infer<typeof resetCodeResultSchema>;
 
+const saveSingleCorrectMcqSelectionInputSchema = z.object({
+  type: z.literal(EnumQuestionType.SingleCorrectMcq),
+  questionId: z.string().min(1),
+  selectedOption: z.string().min(1),
+});
+
+const saveMultiCorrectMcqSelectionInputSchema = z.object({
+  type: z.literal(EnumQuestionType.MultiCorrectMcq),
+  questionId: z.string().min(1),
+  selectedOptions: z.array(z.string().min(1)),
+});
+
 export const saveMcqSelectionInputSchema = z.union([
-  z.object({
-    type: z.literal(EnumQuestionType.SingleCorrectMcq),
-    questionId: z.string().min(1),
-    selectedOption: z.string().min(1),
-  }),
-  z.object({
-    type: z.literal(EnumQuestionType.MultiCorrectMcq),
-    questionId: z.string().min(1),
-    selectedOptions: z.array(z.string().min(1)).min(1),
-  }),
+  saveSingleCorrectMcqSelectionInputSchema,
+  saveMultiCorrectMcqSelectionInputSchema,
 ]);
 
 export type SaveMcqSelectionInput = z.infer<typeof saveMcqSelectionInputSchema>;

--- a/src/utils/classroom/question/saveMcqSelectionInDb.ts
+++ b/src/utils/classroom/question/saveMcqSelectionInDb.ts
@@ -23,6 +23,8 @@ export function saveMcqSelectionInDb({
         )
       );
 
+    if (selectedOptions.length === 0) return;
+
     const selections = selectedOptions.map((so) => ({
       questionId,
       userId,


### PR DESCRIPTION
Previously, saving edits for mcq attempts was incorrectly developed and debouncing, etc wasn't working as expected. With this PR, debounce has been removed completely.

Now a post request is sent to the server every time the radio field (in case of single correct) or one of the checkboxes (in case of multi correct) changes. There is no real throttling except for disabling the form until the request is complete.

Must think about alternatives for better experience - only one so far is to switch to traditional API routes and use the abort controller to abort stale requests